### PR TITLE
Fix SPIClass Has Not Been Defined Compilation Errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.6.7
+
+- Fixes an issue related to the SPI class name, which prevents the compilation of WICED targeted user code that requires SPI support via `SPIClass`. Under WICED, the SPI class is named as `HardwareSPI` in `cores/maple/libmaple/SPI.h` in contrast to the Arduino Core, which as noted, defines the class as `SPIClass`. It is the latter that is most commonly referenced by many other libraries. By providing an alias between the `HardwareSPI` and `SPIClass` names via a `#define`, any previously encountered `'SPIClass' has not been declared` compilation errors should be resolved.
+
 # 0.6.6
 
 - Fix issue uploading with windows 10 by using good-old feather_dfu

--- a/cores/maple/libmaple/SPI.h
+++ b/cores/maple/libmaple/SPI.h
@@ -144,6 +144,15 @@ public:
 
 extern HardwareSPI SPI;
 
+// Fix an issue related to SPI class naming, defined above as `HardwareSPI`, and defined,
+// by the Arduino Core as `SPIClass`. This fix resolves the issue by aliasing the two names.
+// See https://forums.adafruit.com/viewtopic.php?f=24&t=161264 for more information and the
+// inspiration for this bugfix. Credit to `adafruit_support_mike` who on Fri Jan 24, 2020 in
+// the forum noted that the issue should be resolvable by including a #define mapping between
+// the two names. By placing the define here, we obviate the need to include the define in
+// other libraries or user code that depend upon `SPIClass` when building code for the WICED.
+#define SPIClass HardwareSPI;
+
 // Fix Compiler issue with sensor library
 extern uint8_t SPCR;
 

--- a/cores/maple/libmaple/adafruit_featherlib.h
+++ b/cores/maple/libmaple/adafruit_featherlib.h
@@ -60,7 +60,7 @@
 
 //------------- Arduino Shared Structure -------------//
 #define CFG_ARDUINO_CODE_MAGIC    0xDEC0DED
-#define CFG_ARDUINO_CODE_VERSION  "0.6.6"
+#define CFG_ARDUINO_CODE_VERSION  "0.6.7"
 
 #define RESERVED_           XSTRING_CONCAT_(_rerserved, __LINE__)
 

--- a/libraries/AdafruitWicedExamples/library.properties
+++ b/libraries/AdafruitWicedExamples/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit WICED Examples
-version=0.6.6
+version=0.6.7
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Adafruit WICED Feather Examples

--- a/platform.txt
+++ b/platform.txt
@@ -3,7 +3,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification
 
 name=Adafruit WICED (STM32F2 ARM Cortex M3) Boards
-version=0.6.6
+version=0.6.7
 
 # compiler variables
 # ----------------------


### PR DESCRIPTION
Fixes an issue related to the SPI class name, which prevents the
compilation of user code targeted to the Feather WICED board
that requires SPI support via `SPIClass`.

Within the WICED library, the SPI class is named as `HardwareSPI` in
`cores/maple/libmaple/SPI.h`, in contrast to the Arduino Core, which
defines the class as `SPIClass`. It is the latter that is most often referenced
by other libraries and in user code.

By providing a mapping between the `HardwareSPI` and `SPIClass` names
via a `#define`, any `'SPIClass' has not been declared` compilation
errors should be resolved (testing has shown as much). Furthermore, by
specifying the `#define` within `cores/maple/libmaple/SPI.h`, it should
not be necessary to add additional `SPIClass` aliasing `#defines` elsewhere.